### PR TITLE
Update rust.yml

### DIFF
--- a/rust.yml
+++ b/rust.yml
@@ -42,9 +42,7 @@ jobs:
 
       - name: tests
         run: {test_command}
-
 {doctests}
-
       - name: format
         if: github.event_name == 'pull_request' && matrix.lint
         run: {fmt_command}


### PR DESCRIPTION
This change avoid multiple whitespaces in the case we don't need to add doctests (we only need doctests in a library or it breaks the CI).