### PR TITLE
Allow MD028

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -12,6 +12,7 @@
 		"code_blocks": false,
 		"tables": false
 	},
+	"MD028": false,
 	"MD033": {
 		"allowed_elements": [
 			"img"


### PR DESCRIPTION
This markdown lint will allow a blank line inside blockquotes.

This will prevent markdownlint to create errors when having consecutive GitHub alerts, for example:

> [!NOTE]
> Useful information that users should know, even when skimming content.
  
> [!TIP]
> Helpful advice for doing things better or more easily.

https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md028.md