### PR TITLE
Add VS Code defaut settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	// Disable the "unlinked file" notification for files that are not included
+	// in any crate, tipically because they are excluded by OS block fences in
+	// `mod.rs`, for example `#[cfg(target_os = "windows")]` cannot compile
+	// on macOS or Linux.
+	"rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+	// Sign commits by default.
+	"git.enableCommitSigning": true,
 	// Disable the "unlinked file" notification for files that are not included
 	// in any crate, tipically because they are excluded by OS block fences in
 	// `mod.rs`, for example `#[cfg(target_os = "windows")]` cannot compile


### PR DESCRIPTION
- Sign commits by default.
- Disable the "unlinked file" notification for files that are not included in any crate, tipically because they are excluded by OS block fences in`mod.rs`, for example `#[cfg(target_os = "windows")]` cannot compile on macOS or Linux.